### PR TITLE
Fix #111 - remove `jsonlite` + rerun CI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,19 +13,18 @@ Imports:
     dplyr (>= 0.7.0),
     tidyr (>= 1.0.0),
     purrr,
-    jsonlite,
     httr,
     tibble,
     magrittr,
     tidyselect,
     rlang
+Suggests: 
+    httptest,
+    testthat,
+    withr
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
 URL: https://github.com/mattroumaya/surveymonkey
 BugReports: https://github.com/mattroumaya/surveymonkey/issues
-Suggests: 
-    httptest,
-    testthat,
-    withr


### PR DESCRIPTION
Fix #111 
- Modify `DESCRIPTION` to remove `jsonlite` requirement which is not being used
- Test to see if Ubuntu devel CI will pass